### PR TITLE
feat: Add browser tab extraction with convenient API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,32 +6,36 @@
 - Cross-platform app focus tracking for macOS and Windows
 - Real-time focus event streaming with configurable update intervals
 - Comprehensive application information extraction
+- **Browser tab extraction** - Automatic detection and parsing of web browser tabs (domain, URL, title)
 - Platform-specific permission handling (macOS accessibility, Windows process monitoring)
 - Support for system app filtering and duration tracking
 - Extensive error handling with platform-specific exceptions
 
 **Platform Support:**
-- **macOS**: Full implementation with accessibility permissions, bundle identifier extraction, and sandboxing support
-- **Windows**: Complete implementation with Win32 API integration, UWP app support, and UAC handling
+- **macOS**: Full implementation with accessibility permissions, bundle identifier extraction, sandboxing support, and browser tab extraction via Accessibility API
+- **Windows**: Complete implementation with Win32 API integration, UWP app support, UAC handling, and browser tab extraction via window title parsing
 - **Other Platforms**: Graceful fallback with platform not supported exceptions
 
 **API:**
 - `AppFocusTracker`: Main plugin class with focus tracking capabilities
 - `FocusTrackerConfig`: Configuration options for tracking behavior
 - `FocusEvent`: Data model for focus change events
-- `AppInfo`: Data model for application information
+- `AppInfo`: Data model for application information with browser detection
+- `BrowserTabInfo`: Data model for browser tab information
 - `FocusEventType`: Enumeration of event types (gained, lost, durationUpdate, switched)
 
 **Testing:**
-- Comprehensive test suite with 155+ tests covering:
+- Comprehensive test suite with 160+ tests covering:
   - Unit tests for data models and core functionality
   - Integration tests for end-to-end workflows
   - Platform-specific tests for macOS and Windows features
   - Performance and stress tests for reliability
   - Mock platform implementation for testing scenarios
+  - Browser tab extraction tests
 
 **Documentation:**
 - Complete API documentation and usage examples
 - Platform-specific feature documentation
 - Error handling guide
 - Testing instructions
+- Browser tab extraction examples

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Flutter plugin for tracking application focus changes across macOS and Windows
 - **Cross-Platform Support**: Native implementations for macOS and Windows
 - **Real-Time Focus Tracking**: Stream-based API for live focus change events
 - **Application Information**: Detailed metadata about running applications
+- **Browser Tab Extraction**: Automatic detection and parsing of web browser tabs (domain, URL, title)
 - **Permission Management**: Automatic handling of platform-specific permissions
 - **Performance Optimized**: Efficient event handling with configurable update intervals
 - **Comprehensive Testing**: Extensive test suite covering unit, integration, and performance tests
@@ -58,6 +59,17 @@ void main() async {
       print('App focused: ${event.appName}');
       print('Duration: ${event.duration}');
       print('Event type: ${event.eventType}');
+      
+      // Check if it's a browser and extract tab information
+      if (event.isBrowser) {
+        final tab = event.browserTab;
+        if (tab != null) {
+          print('Browser: ${tab.browserType}');
+          print('Domain: ${tab.domain}');
+          print('URL: ${tab.url}');
+          print('Title: ${tab.title}');
+        }
+      }
     });
     
     // Get current focused application
@@ -133,6 +145,22 @@ class AppInfo {
   final String? iconPath;
   final String? executablePath;
   final Map<String, dynamic>? metadata;
+  
+  /// Whether this application is a recognised web browser
+  bool get isBrowser;
+  
+  /// Parsed browser tab info when [isBrowser] is true
+  BrowserTabInfo? get browserTab;
+}
+```
+
+#### BrowserTabInfo
+```dart
+class BrowserTabInfo {
+  final String? domain;      // e.g., "stackoverflow.com"
+  final String? url;         // e.g., "https://stackoverflow.com"
+  final String title;        // Page title
+  final String browserType;  // "chrome", "edge", "firefox", etc.
 }
 ```
 
@@ -144,6 +172,7 @@ class AppInfo {
 - App version information
 - Sandboxing support
 - Mission Control integration
+- Browser tab extraction via Accessibility API
 
 ### Windows
 - Process monitoring via Win32 API
@@ -151,6 +180,7 @@ class AppInfo {
 - UAC elevation handling
 - Multi-monitor support
 - Virtual desktop detection
+- Browser tab extraction via window title parsing
 
 ## Error Handling
 

--- a/lib/src/models/app_info.dart
+++ b/lib/src/models/app_info.dart
@@ -2,6 +2,8 @@
 ///
 /// This class provides comprehensive metadata about an application
 /// including platform-specific identifiers and optional details.
+import 'browser_tab_info.dart';
+
 class AppInfo {
   /// The display name of the application
   final String name;
@@ -61,6 +63,18 @@ class AppInfo {
       'executablePath': executablePath,
       'metadata': metadata,
     };
+  }
+
+  /// Whether this application is a recognised web browser.
+  bool get isBrowser => (metadata?['isBrowser'] as bool?) ?? false;
+
+  /// Parsed browser tab info when [isBrowser] is true and data available, otherwise null.
+  BrowserTabInfo? get browserTab {
+    final tabJson = metadata?['browserTab'];
+    if (tabJson is Map<String, dynamic>) {
+      return BrowserTabInfo.fromJson(tabJson);
+    }
+    return null;
   }
 
   @override

--- a/lib/src/models/browser_tab_info.dart
+++ b/lib/src/models/browser_tab_info.dart
@@ -1,0 +1,46 @@
+/// Information about a browser tab extracted from window title metadata.
+///
+/// This model is only populated when the focused application is recognised
+/// as a desktop browser (Chrome, Edge, Firefox, Brave, Safari, etc.) and
+/// when the native platform code successfully parsed the window title.
+class BrowserTabInfo {
+  /// Domain part of the website (e.g. `stackoverflow.com`).
+  final String? domain;
+
+  /// Full URL constructed from the domain if available (e.g. `https://stackoverflow.com`).
+  final String? url;
+
+  /// Page title (cleaned, without the browser-name suffix).
+  final String title;
+
+  /// Browser type in lowercase (`chrome`, `edge`, `firefox`, ...).
+  final String browserType;
+
+  const BrowserTabInfo({
+    this.domain,
+    this.url,
+    required this.title,
+    required this.browserType,
+  });
+
+  factory BrowserTabInfo.fromJson(Map<String, dynamic> json) {
+    return BrowserTabInfo(
+      domain: json['domain'] as String?,
+      url: json['url'] as String?,
+      title: json['title'] as String? ?? '',
+      browserType: json['browserType'] as String? ?? 'browser',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'domain': domain,
+      'url': url,
+      'title': title,
+      'browserType': browserType,
+    }..removeWhere((_, v) => v == null);
+  }
+
+  @override
+  String toString() => 'BrowserTabInfo(domain: $domain, title: $title, browserType: $browserType)';
+}

--- a/lib/src/models/focus_event.dart
+++ b/lib/src/models/focus_event.dart
@@ -1,3 +1,5 @@
+import 'browser_tab_info.dart';
+
 /// Represents a single application focus event with timing information.
 ///
 /// This immutable class contains all the data associated with an application
@@ -30,6 +32,18 @@ class FocusEvent {
 
   /// Additional metadata about the application (version, icon path, etc.)
   final Map<String, dynamic>? metadata;
+
+  /// Whether the focused application is a recognised web browser
+  bool get isBrowser => (metadata?['isBrowser'] as bool?) ?? false;
+
+  /// Parsed browser tab info when [isBrowser] is true and data available
+  BrowserTabInfo? get browserTab {
+    final tabJson = metadata?['browserTab'];
+    if (tabJson is Map<String, dynamic>) {
+      return BrowserTabInfo.fromJson(tabJson);
+    }
+    return null;
+  }
 
   /// Creates a new [FocusEvent] instance.
   ///

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -2,3 +2,4 @@
 export 'focus_event.dart';
 export 'app_info.dart';
 export 'focus_tracker_config.dart';
+export 'browser_tab_info.dart';

--- a/test/models/browser_info_test.dart
+++ b/test/models/browser_info_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:app_focus_tracker/src/models/app_info.dart';
+import 'package:app_focus_tracker/src/models/browser_tab_info.dart';
+
+void main() {
+  group('AppInfo Browser Extensions', () {
+    test('isBrowser returns true when metadata flag is set', () {
+      const info = AppInfo(
+        name: 'Google Chrome',
+        identifier: 'com.google.Chrome',
+        metadata: {
+          'isBrowser': true,
+        },
+      );
+
+      expect(info.isBrowser, isTrue);
+    });
+
+    test('isBrowser returns false when flag missing or false', () {
+      const info1 = AppInfo(
+        name: 'Finder',
+        identifier: 'com.apple.finder',
+      );
+      const info2 = AppInfo(
+        name: 'Edge',
+        identifier: 'com.microsoft.edgemac',
+        metadata: {'isBrowser': false},
+      );
+
+      expect(info1.isBrowser, isFalse);
+      expect(info2.isBrowser, isFalse);
+    });
+
+    test('browserTab parses tab metadata into BrowserTabInfo', () {
+      const metadata = {
+        'isBrowser': true,
+        'browserTab': {
+          'domain': 'example.com',
+          'url': 'https://example.com',
+          'title': 'Example Domain',
+          'browserType': 'chrome',
+        }
+      };
+
+      const info = AppInfo(
+        name: 'Google Chrome - Example Domain',
+        identifier: 'com.google.Chrome',
+        metadata: metadata,
+      );
+
+      final BrowserTabInfo? tab = info.browserTab;
+      expect(tab, isNotNull);
+      expect(tab!.domain, equals('example.com'));
+      expect(tab.url, equals('https://example.com'));
+      expect(tab.title, equals('Example Domain'));
+      expect(tab.browserType, equals('chrome'));
+    });
+
+    test('browserTab returns null when metadata absent', () {
+      const info = AppInfo(
+        name: 'Not a browser',
+        identifier: 'com.test.app',
+      );
+
+      expect(info.browserTab, isNull);
+    });
+  });
+}

--- a/test/models/focus_event_test.dart
+++ b/test/models/focus_event_test.dart
@@ -331,5 +331,66 @@ void main() {
         expect(event2.eventId, startsWith('evt_'));
       });
     });
+
+    group('Browser Information', () {
+      test('isBrowser returns true when metadata flag is set', () {
+        final event = FocusEvent(
+          appName: 'Google Chrome',
+          durationMicroseconds: 1000,
+          metadata: {'isBrowser': true},
+        );
+
+        expect(event.isBrowser, isTrue);
+      });
+
+      test('isBrowser returns false when flag missing or false', () {
+        final event1 = FocusEvent(
+          appName: 'Finder',
+          durationMicroseconds: 1000,
+        );
+        final event2 = FocusEvent(
+          appName: 'Edge',
+          durationMicroseconds: 1000,
+          metadata: {'isBrowser': false},
+        );
+
+        expect(event1.isBrowser, isFalse);
+        expect(event2.isBrowser, isFalse);
+      });
+
+      test('browserTab parses tab metadata into BrowserTabInfo', () {
+        final metadata = {
+          'isBrowser': true,
+          'browserTab': {
+            'domain': 'example.com',
+            'url': 'https://example.com',
+            'title': 'Example Domain',
+            'browserType': 'chrome',
+          }
+        };
+
+        final event = FocusEvent(
+          appName: 'Google Chrome - Example Domain',
+          durationMicroseconds: 1000,
+          metadata: metadata,
+        );
+
+        final tab = event.browserTab;
+        expect(tab, isNotNull);
+        expect(tab!.domain, equals('example.com'));
+        expect(tab.url, equals('https://example.com'));
+        expect(tab.title, equals('Example Domain'));
+        expect(tab.browserType, equals('chrome'));
+      });
+
+      test('browserTab returns null when metadata absent', () {
+        final event = FocusEvent(
+          appName: 'Not a browser',
+          durationMicroseconds: 1000,
+        );
+
+        expect(event.browserTab, isNull);
+      });
+    });
   });
 }

--- a/test/test_runner.dart
+++ b/test/test_runner.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'models/focus_event_test.dart' as focus_event_tests;
 import 'models/app_info_test.dart' as app_info_tests;
 import 'models/focus_tracker_config_test.dart' as config_tests;
+import 'models/browser_info_test.dart' as browser_info_tests;
 
 // Core platform tests
 import 'platform_interface_test.dart' as platform_interface_tests;
@@ -24,6 +25,7 @@ void main() {
       group('FocusEvent', focus_event_tests.main);
       group('AppInfo', app_info_tests.main);
       group('FocusTrackerConfig', config_tests.main);
+      group('BrowserInfo', browser_info_tests.main);
     });
 
     group('🔌 Platform Interface Tests', () {
@@ -168,6 +170,11 @@ class TestRegistry {
       name: 'FocusTrackerConfig Tests',
       category: TestCategory.unit,
       estimatedDuration: Duration(seconds: 4),
+    ),
+    TestMetadata(
+      name: 'BrowserInfo Model Tests',
+      category: TestCategory.unit,
+      estimatedDuration: Duration(seconds: 2),
     ),
 
     // Platform Interface Tests


### PR DESCRIPTION
- Add browser detection and tab info extraction for Chrome, Edge, Firefox, Brave, Safari
- Implement native browser tab parsing on Windows (window title) and macOS (accessibility API)
- Add BrowserTabInfo model with domain, URL, title, and browser type
- Add convenient getters to FocusEvent: isBrowser and browserTab
- Update AppInfo with browser detection capabilities
- Add comprehensive unit tests for browser functionality
- Update documentation with browser tab extraction examples
- Integrate browser tests into test runner

This enables easy access to website information when tracking browser focus: event.isBrowser && event.browserTab?.domain